### PR TITLE
Added "mesh_img.py" and "plot_mesh.py".

### DIFF
--- a/pyeit/mesh/mesh_img.py
+++ b/pyeit/mesh/mesh_img.py
@@ -1,0 +1,33 @@
+import numpy as np
+from wrapper import create
+
+
+def groundtruth_IMG_based(IMG, n_el=16, perm_empty_gnd=1, perm_obj=10, h0=0.1):
+    """
+    Wraps a image to the PyEITMesh unit circle area.
+
+    input:   - 200x200 image
+             - n_el: number of electrodes
+             - perm_empty_gnd: perm of the empty ground
+             - perm_obj: perm ob the object area
+             - h0: refinement of the mesh
+
+    return: mesh_obj (PyEITMesh)
+    """
+
+    mesh_obj = create(n_el=n_el, h0=h0)
+    X_Y = np.array(np.where(IMG == 1))
+    X = X_Y[1, :] - 100
+    Y = (X_Y[0, :] - 100) * -1
+    pts = mesh_obj.element
+    tri = mesh_obj.node
+    tri_centers = np.mean(tri[pts], axis=1)
+    mesh_x = np.round(tri_centers[:, 0] * 100)
+    mesh_y = np.round(tri_centers[:, 1] * 100)
+    Perm = np.ones(tri_centers.shape[0]) * perm_empty_gnd
+    for i in range(len(X)):
+        for j in range(len(mesh_x)):
+            if X[i] == mesh_x[j] and Y[i] == mesh_y[j]:
+                Perm[j] = perm_obj
+    mesh_obj.perm = Perm
+    return mesh_obj

--- a/pyeit/mesh/plot_mesh.py
+++ b/pyeit/mesh/plot_mesh.py
@@ -3,7 +3,7 @@ import matplotlib.pyplot as plt
 
 
 def plot_mesh(mesh_obj):
-    """Plot PyEITMesh """
+    """Plot PyEITMesh"""
     plt.style.use("default")
     pts = mesh_obj.node
     tri = mesh_obj.element

--- a/pyeit/mesh/plot_mesh.py
+++ b/pyeit/mesh/plot_mesh.py
@@ -1,0 +1,31 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def plot_mesh(mesh_obj):
+    """Plot PyEITMesh """
+    plt.style.use("default")
+    pts = mesh_obj.node
+    tri = mesh_obj.element
+    x, y = pts[:, 0], pts[:, 1]
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+    ax.tripcolor(
+        x,
+        y,
+        tri,
+        np.real(mesh_obj.perm),
+        edgecolors="k",
+        shading="flat",
+        alpha=0.5,
+        cmap=plt.cm.viridis,
+    )
+    # draw electrodes
+    ax.plot(x[mesh_obj.el_pos], y[mesh_obj.el_pos], "ro")
+    for i, e in enumerate(mesh_obj.el_pos):
+        ax.text(x[e], y[e], str(i + 1), size=12)
+    ax.set_title(r"mesh")
+    ax.set_aspect("equal")
+    ax.set_ylim([-1.2, 1.2])
+    ax.set_xlim([-1.2, 1.2])
+    fig.set_size_inches(6, 6)


### PR DESCRIPTION
The file "mesh_img.py" provides a way to generate any kind of object inside the pyEIT unit circle mesh.

With "plot_mesh.py" it´s possible to plot a pyEITmesh.

A preview of the function is shown in the following repository:
https://github.com/JacobTh98/pyEIT_image_wrapper