### PR TITLE
Allow Inhomogeneous Measurement Patterns (Accelerate)

### DIFF
--- a/examples/eit_static_jac.py
+++ b/examples/eit_static_jac.py
@@ -16,7 +16,7 @@ from pyeit.mesh.wrapper import PyEITAnomaly_Circle
 # Mesh shape is specified with fd parameter in the instantiation, e.g:
 # from pyeit.mesh.shape import thorax
 # mesh_obj, el_pos = create(n_el, h0=0.05, fd=thorax)  # Default : fd=circle
-n_el = 32  # test fem_vectorize
+n_el = 64  # test fem_vectorize
 mesh_obj = create(n_el, h0=0.05)
 # set anomaly (altering the permittivity in the mesh)
 anomaly = [

--- a/examples/eit_static_jac.py
+++ b/examples/eit_static_jac.py
@@ -16,7 +16,7 @@ from pyeit.mesh.wrapper import PyEITAnomaly_Circle
 # Mesh shape is specified with fd parameter in the instantiation, e.g:
 # from pyeit.mesh.shape import thorax
 # mesh_obj, el_pos = create(n_el, h0=0.05, fd=thorax)  # Default : fd=circle
-n_el = 64  # test fem_vectorize
+n_el = 32  # test fem_vectorize
 mesh_obj = create(n_el, h0=0.05)
 # set anomaly (altering the permittivity in the mesh)
 anomaly = [

--- a/pyeit/eit/fem.py
+++ b/pyeit/eit/fem.py
@@ -245,7 +245,7 @@ class EITForward(Forward):
         ri = subtract_row_vectorized(r_el, self.protocol.meas_mat)
         v0 = v.reshape(-1)
 
-        ## calculate v, jac per excitation pattern (ex_line)
+        ## calculate v, jac per excitation (ex_line)
         # _jac = np.zeros((self.protocol.n_meas, self.mesh.n_elems), dtype=self.mesh.dtype)
         # for i, ex_line in enumerate(self.protocol.ex_mat):
         #     f = self.solve(ex_line)
@@ -253,19 +253,15 @@ class EITForward(Forward):
         #     ri = subtract_row(r_el, self.protocol.meas_mat[i])
         #     for (e, ijk) in enumerate(self.mesh.element):
         #         _jac[i, :, e] = np.dot(np.dot(ri[:, ijk], self.se[e]), f[ijk])
-        ## measurement protocol
         # jac = np.concatenate(_jac)
 
         # Build Jacobian matrix element wise (column wise)
-        #    Je = Re*Ke*Ve = (n_measx3) * (3x3) * (3x1)
+        # Je = Re*Ke*Ve = (n_measx3) * (3x3) * (3x1)
         jac = np.zeros((self.protocol.n_meas, self.mesh.n_elems), dtype=self.mesh.dtype)
-        # for i in range(self.protocol.ex_mat.shape[0]):
         indices = self.protocol.meas_mat[:, 2]
+        f_n = f[indices]  # replica of potential on nodes of difference excitations
         for e, ijk in enumerate(self.mesh.element):
-            # todo: multiple replica of f[ijk], not efficient
-            jac[:, e] = np.sum(
-                np.dot(ri[:, ijk], self.se[e]) * f[indices][:, ijk], axis=1
-            )
+            jac[:, e] = np.sum(np.dot(ri[:, ijk], self.se[e]) * f_n[:, ijk], axis=1)
 
         # Jacobian normalization: divide each row of J (J[i]) by abs(v0[i])
         if normalize:


### PR DESCRIPTION
Previously, `meas_mat` is a 3-dimensional ndarray which represents the excitation id and the differential pairs ` [n, m] `. What if we want to combine the differential pairs of `adjacent` (16 elctrodes, 13 measurements per exc) and `opposite` (16 electrodes, 12 measurements per exc) excitations?

This PR implements a vstacked version os `meas_mat`. Now `meas_mat` is a 2-dimensional array, of size `n_meas x 3`. Each column represents ` [n, m, exc_id] `.

The benefit of using this type of measurement matrix is that:

1. it allows inhomogeneous excitation patterns of different number of measurements. Moreover, you could write your own customized measurement [n, m, exc_ids] easily.
2. it allows fast implementation of `subtract_row_vectorized` and `smear_nd` and a much cleaner implementation of calculating `jac`, see the code accordingly.

