### PR TITLE
daeger eit load offset error, add offset 8->16

### DIFF
--- a/pyeit/io/daeger_eit.py
+++ b/pyeit/io/daeger_eit.py
@@ -76,7 +76,7 @@ class DAEGER_EIT:
         with open(fname, "rb") as fh:
             b = fh.read(16)
             a = struct.unpack("8H", b)
-            offset = a[2] + 8
+            offset = a[2] + 16
 
         # number of frames
         nframe = int((flen - offset) / spc)


### PR DESCRIPTION
There is 1 data offset when using `DAEGER_EIT`, correct this offset via 8 -> 16.